### PR TITLE
Don't use deprecated API

### DIFF
--- a/emacs.d/init/init-git-gutter.el
+++ b/emacs.d/init/init-git-gutter.el
@@ -1,6 +1,6 @@
 (global-git-gutter-mode +1)
 
 (smartrep-define-key global-map  "C-x"
-  '(("p" . 'git-gutter:previous-diff)
-    ("n" . 'git-gutter:next-diff)))
+  '(("p" . 'git-gutter:previous-hunk)
+    ("n" . 'git-gutter:next-hunk)))
 


### PR DESCRIPTION
`git-gutter:next-diff` and `git-gutter:previous-diff` are deprecated interfaces.

Thanks for using my product :smile_cat:
